### PR TITLE
Remove @tf.function decorators from FIR helper closures

### DIFF
--- a/nems/layers/filter.py
+++ b/nems/layers/filter.py
@@ -360,15 +360,12 @@ class FiniteImpulseResponse(Layer):
             # dimension of input in call function.
             if new_inputs.ndim > fake_inputs.ndim:
                 # A singleton output dimension needs to be appended as well.
-                @tf.function
                 def expand_inputs(inputs):
                     return tf.expand_dims(inputs, axis=-1)
             else:
-                @tf.function
                 def expand_inputs(inputs):
                     return inputs
 
-            @tf.function()
             def broadcast_inputs(inputs):
                 # Convert None batch shape to int, add singleton output dim
                 # if needed. Then broadcast outputs.
@@ -380,7 +377,6 @@ class FiniteImpulseResponse(Layer):
             # print(new_inputs_shape)
             # print(input_shape)
 
-            @tf.function()
             def broadcast_inputs(inputs):
                 # Convert None batch shape to int, add singleton output dim
                 # if needed. Then broadcast outputs.
@@ -397,7 +393,6 @@ class FiniteImpulseResponse(Layer):
 
         else:
             # Otherwise, don't need to do anything to inputs.
-            @tf.function
             def broadcast_inputs(inputs):
                 # This will still add a singleton output dim if needed.
                 #return tf.reshape(inputs, new_inputs_shape)
@@ -410,7 +405,6 @@ class FiniteImpulseResponse(Layer):
                 return tf.broadcast_to(coefficients, new_coefs_shape)
         else:
             # Otherwise, don't need to do anything to coefficients.
-            @tf.function
             def broadcast_coefficients(coefficients): return coefficients
         
         return broadcast_inputs, broadcast_coefficients, n_outputs
@@ -436,7 +430,6 @@ class FiniteImpulseResponse(Layer):
         stride = self.stride
         if num_gpus == 0:
             # Use CPU-compatible (but slower) version.
-            @tf.function
             def convolve(inputs, coefficients):
                 # Reorder coefficients to shape (n outputs, time, rank, 1)
                 new_coefs = tf.expand_dims(
@@ -468,7 +461,6 @@ class FiniteImpulseResponse(Layer):
                 return z
         else:
             # Use GPU-only version (grouped convolutions), much faster.
-            @tf.function
             def convolve(inputs, coefficients):
                 input_width = tf.shape(inputs)[1]
                 # Reshape will group by output before rank w/o transpose.


### PR DESCRIPTION
broadcast_inputs, broadcast_coefficients, and convolve are all called inside Keras call() during symbolic tracing. Keras 3 already compiles call() into a graph; nested @tf.function decorators cause double-tracing conflicts, the same issue fixed in Conv2d (f8976e5). Removing them follows the same pattern.

https://claude.ai/code/session_01NTe6x36BbPJADwp3fq9Vj2